### PR TITLE
Android SDK 35 (Android 15)への更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ app/src/main/java/com/kireaji/minimallauncherapp/
 - **UI**: Jetpack Compose + 従来の View システム（移行中）
 - **DI**: Hilt 2.44
 - **ビルドツール**: Gradle 8.10.1、Kotlin 1.8.20
-- **最小 SDK**: 26 / ターゲット SDK: 33
+- **最小 SDK**: 26 / ターゲット SDK: 35 (Android 15)
 - **Java バージョン**: 17
 - **テスト**: JUnit 4.13.2、Mockito 3.12.4
 - **Firebase**: Analytics、Crashlytics、Performance Monitoring

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,12 +13,12 @@ plugins {
 
 android {
     namespace ="com.kireaji.minimallauncherapp"
-    compileSdk = 33
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.kireaji.minimallauncherapp"
         minSdk = 26
-        targetSdk = 33
+        targetSdk = 35
         versionCode = 130
         versionName = "1.3.0"
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.kireaji.minimallauncherapp">
 
-    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
+    <!-- Launcher app needs to query all installed packages -->
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"
+        tools:ignore="QueryAllPackagesPermission" />
 
     <application
         android:name=".MyApplication"


### PR DESCRIPTION
## 📋 概要
Android SDK バージョンを API Level 35 (Android 15) に更新しました。

## 🔧 変更内容
- `app/build.gradle.kts` の `compileSdk` を 33 → 35 に更新
- `app/build.gradle.kts` の `targetSdk` を 33 → 35 に更新
- AndroidManifest.xml で「`QUERY_ALL_PACKAGES` 権限」の lint 警告を抑制
- CLAUDE.md のターゲット SDK 情報を更新

## ✅ テスト結果
- ビルド: 成功
- Lint チェック: エラー 0 件
- ユニットテスト: 全て成功

## 🎯 目的
Google Play Store の要件に対応し、Android 15 の新機能とセキュリティ改善の恩恵を受けるための更新。

Closes #5

Generated with [Claude Code](https://claude.ai/code)