### PR TITLE
:up: Update Gradle version from 8.11.1 to 8.14.3

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Resolves Android Lint warning AndroidGradlePluginVersion

Updates gradle-wrapper.properties to use the latest stable Gradle release

Fixes # 22

Generated with [Claude Code](https://claude.ai/code)