### PR TITLE
fix: Remove redundant android:label from activity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,6 @@
         <activity
             android:name="com.kireaji.minimallauncherapp.ui.FullscreenActivity"
             android:configChanges="orientation|keyboardHidden|screenSize"
-            android:label="@string/app_name"
             android:exported="true" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
Fixes #21

## 修正内容
- AndroidManifest.xml から冗長な android:label 属性を削除
- RedundantLabel lint 警告を解消

## 検証結果
- ✅ Android lint: RedundantLabel 警告が解消
- ✅ ユニットテスト: 全テスト成功
- ✅ ビルド: デバッグビルド正常完了

Generated with [Claude Code](https://claude.ai/code)