### PR TITLE
:shirt: Update targetSdk from 35 to 36 to resolve OldTargetApi lint warning

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,12 +22,12 @@ plugins {
 
 android {
     namespace ="com.kireaji.minimallauncherapp"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.kireaji.minimallauncherapp"
         minSdk = 26
-        targetSdk = 35
+        targetSdk = 36
         versionCode = 133
         versionName = "1.3.3"
 


### PR DESCRIPTION
Android LintのOldTargetApi警告を修正しました。

## 変更内容
- `targetSdk`を 35 から 36 に更新
- `compileSdk`を 35 から 36 に更新

## 検証完了
- ✅ Android Lint チェック - OldTargetApi警告が解消
- ✅ ユニットテスト成功
- ✅ ビルド成功

Fixes #19

Generated with [Claude Code](https://claude.ai/code)