### PR TITLE
🆙 Update Kotlin stdlib version to 1.9.24

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,9 +77,9 @@ kotlin {
 
 dependencies {
 
-    implementation ("org.jetbrains.kotlin:kotlin-stdlib:1.8.20")
+    implementation ("org.jetbrains.kotlin:kotlin-stdlib:1.9.24")
     implementation ("androidx.core:core-ktx:1.8.0")
-    implementation (platform("org.jetbrains.kotlin:kotlin-bom:1.8.0"))
+    implementation (platform("org.jetbrains.kotlin:kotlin-bom:1.9.24"))
     implementation ("androidx.activity:activity-compose:1.5.1")
     implementation (platform("androidx.compose:compose-bom:2022.10.00"))
     implementation ("androidx.compose.ui:ui")


### PR DESCRIPTION
Fix Android lint GradleDependency warning by updating Kotlin stdlib dependencies

## 変更内容
- `org.jetbrains.kotlin:kotlin-stdlib`: 1.8.20 → 1.9.24
- `org.jetbrains.kotlin:kotlin-bom`: 1.8.0 → 1.9.24

## 動作確認
- ✅ ビルド成功
- ✅ lint チェック成功
- ✅ テスト成功

## 関連イシュー
Closes #23

Generated with [Claude Code](https://claude.ai/code)