### PR TITLE
👕 Add dataExtractionRules for Android 12+

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <application
         android:name=".MyApplication"
         android:allowBackup="false"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <!-- 
+        Android 12以降でのデータ抽出ルール設定
+        現在のポリシー: バックアップを無効化
+    -->
+    <cloud-backup>
+        <!-- クラウドバックアップを無効化 -->
+        <exclude domain="root" />
+        <exclude domain="database" />
+        <exclude domain="sharedpref" />
+        <exclude domain="external" />
+        <exclude domain="file" />
+    </cloud-backup>
+    
+    <device-transfer>
+        <!-- デバイス間転送を無効化 -->
+        <exclude domain="root" />
+        <exclude domain="database" />
+        <exclude domain="sharedpref" />
+        <exclude domain="external" />
+        <exclude domain="file" />
+    </device-transfer>
+</data-extraction-rules>


### PR DESCRIPTION
Issue #27 の Android Lint 警告を修正。

## 変更内容
- `res/xml/data_extraction_rules.xml` を作成し、バックアップ無効化ポリシーを設定
- AndroidManifest.xml に `android:dataExtractionRules="@xml/data_extraction_rules"` を追加
- 既存の `android:allowBackup="false"` はAndroid 12未満との互換性のため保持

Fixes #27

Generated with [Claude Code](https://claude.ai/code)