### PR TITLE
[PP-1] :shirt: Remove unused R.color.white resource

### DIFF
--- a/app/src/main/res/values/color_palette.xml
+++ b/app/src/main/res/values/color_palette.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="black">#FF000000</color>
-    <color name="white">#FFFFFFFF</color>
     <color name="light_blue_600">#FF039BE5</color>
     <color name="light_blue_900">#FF01579B</color>
     <color name="light_blue_A200">#FF40C4FF</color>


### PR DESCRIPTION
Fix Android Lint UnusedResources warning by removing the unused `R.color.white` resource

Resolves #35

## Changes
- Removed unused white color resource from color_palette.xml
- The resource was not referenced anywhere in the codebase
- Verified that minimal_white is used instead throughout the app

## Quality Checks
- ✅ Lint check passed
- ✅ Unit tests passed
- ✅ Debug build successful

Generated with [Claude Code](https://claude.ai/code)