### PR TITLE
fix: Notion ID 抽出ロジックの無限ループを修正

### DIFF
--- a/.github/workflows/notion-pr-connector.yml
+++ b/.github/workflows/notion-pr-connector.yml
@@ -26,34 +26,23 @@ jobs:
         id: extract
         run: |
           TITLE="${{ github.event.pull_request.title }}"
-          BEFORE_TITLE="${{ github.event.changes.title.from }}"
+          BEFORE_TITLE="${{ github.event.changes.title.from || '' }}"
+
+          echo "📋 PR タイトル: $TITLE"
+          echo "📋 以前のタイトル: $BEFORE_TITLE"
 
           # 現在のタイトルから全 ID を抽出（複数対応）
+          # grep -oE で全マッチを抽出し、sed でブラケットを除去
           NOTION_IDS=""
-          TEMP_TITLE="$TITLE"
-          while [[ $TEMP_TITLE =~ \[([A-Z]+-[0-9]+)\] ]]; do
-            ID="${BASH_REMATCH[1]}"
-            if [ -z "$NOTION_IDS" ]; then
-              NOTION_IDS="$ID"
-            else
-              NOTION_IDS="$NOTION_IDS,$ID"
-            fi
-            TEMP_TITLE="${TEMP_TITLE/${BASH_REMATCH[0]}/}"
-          done
+          if echo "$TITLE" | grep -qE '\[[A-Z]+-[0-9]+\]'; then
+            # 全ての [ID] パターンを抽出して、カンマ区切りに変換
+            NOTION_IDS=$(echo "$TITLE" | grep -oE '\[[A-Z]+-[0-9]+\]' | sed 's/\[//g' | sed 's/\]//g' | paste -sd ',' -)
+          fi
 
           # 以前のタイトルから ID 抽出（edited イベント用）
           BEFORE_IDS=""
-          if [ -n "$BEFORE_TITLE" ]; then
-            TEMP_BEFORE="$BEFORE_TITLE"
-            while [[ $TEMP_BEFORE =~ \[([A-Z]+-[0-9]+)\] ]]; do
-              ID="${BASH_REMATCH[1]}"
-              if [ -z "$BEFORE_IDS" ]; then
-                BEFORE_IDS="$ID"
-              else
-                BEFORE_IDS="$BEFORE_IDS,$ID"
-              fi
-              TEMP_BEFORE="${TEMP_BEFORE/${BASH_REMATCH[0]]/}"
-            done
+          if [ -n "$BEFORE_TITLE" ] && echo "$BEFORE_TITLE" | grep -qE '\[[A-Z]+-[0-9]+\]'; then
+            BEFORE_IDS=$(echo "$BEFORE_TITLE" | grep -oE '\[[A-Z]+-[0-9]+\]' | sed 's/\[//g' | sed 's/\]//g' | paste -sd ',' -)
           fi
 
           echo "notion_ids=$NOTION_IDS" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## 🐛 問題

PR #36 でマージされた Notion PR Connector ワークフローに無限ループのバグがありました。

### 現象
- Extract Notion IDs from PR title ステップで処理が停止（11分以上）
- 原因: while ループによる文字列置換が失敗し、無限ループが発生
- 特に絵文字などの特殊文字が含まれる PR タイトルで問題が顕在化

### 影響範囲
- PR タイトルに [PP-1] などの Notion ID を含む全ての PR
- 例: [PP-1] 👕 Remove unused R.color.white resource

## ✅ 修正内容

### 改善点
1. **無限ループの完全排除**
   - while ループを使わず、grep -oE で一度に全マッチを抽出
   - パイプラインで安全に処理（grep → sed → paste）

2. **デバッグ出力の追加**
   - PR タイトルをログに表示

3. **安全なデフォルト値**
   - BEFORE_TITLE のデフォルト値設定

## 🧪 テスト結果

### テストケース 1: 通常のPRタイトル
- **入力**: [PP-1] 機能追加
- **期待**: PP-1 を抽出
- **結果**: ✅ 成功

### テストケース 2: 絵文字を含むPRタイトル
- **入力**: [PP-1] 👕 Remove unused resource
- **期待**: PP-1 を抽出
- **結果**: ✅ 成功（修正前は無限ループ）

### テストケース 3: 複数ID
- **入力**: [PP-1][PP-2] 複数タスク対応
- **期待**: PP-1,PP-2 を抽出
- **結果**: ✅ 成功

## 📊 影響

- ✅ 既存の機能に影響なし（ロジックの改善のみ）
- ✅ 実行時間: 変更なし（数秒）
- ✅ 出力結果: 変更なし（同じフォーマット）

## 🚀 デプロイ後の確認事項

マージ後、以下を確認してください:
1. Notion ID を含む PR でワークフローが正常に完了すること
2. ワークフローのログに 抽出された Notion ID: PP-X と表示されること
3. 無限ループが発生しないこと（実行時間が30秒以内）

---
🤖 Generated with Claude Code