### PR TITLE
fix: Notion PR Connector の bash -e エラーを修正

### DIFF
--- a/.github/workflows/notion-pr-connector.yml
+++ b/.github/workflows/notion-pr-connector.yml
@@ -54,7 +54,9 @@ jobs:
           else
             echo "has_notion_id=true" >> $GITHUB_OUTPUT
             echo "✅ 抽出された Notion ID: $NOTION_IDS"
-            [ -n "$BEFORE_IDS" ] && echo "📝 以前の Notion ID: $BEFORE_IDS"
+            if [ -n "$BEFORE_IDS" ]; then
+              echo "📝 以前の Notion ID: $BEFORE_IDS"
+            fi
           fi
 
       # 3. イベント別のステータス値を決定


### PR DESCRIPTION
## 🐛 問題

PR #38 でマージされた修正にまだ bash -e のエラーが残っていました。

### 現象
- Extract Notion IDs from PR title ステップで exit code 1 が発生
- ワークフロー全体が失敗する

### 原因
以下の行が問題：
```bash
[ -n "$BEFORE_IDS" ] && echo "📝 以前の Notion ID: $BEFORE_IDS"
```

BEFORE_IDS が空の場合、`[ -n "$BEFORE_IDS" ]` が false を返し、
bash の `-e` オプション（エラー時に即座に終了）により、
スクリプト全体が exit code 1 で終了してしまう。

## ✅ 修正内容

### 変更前
```bash
[ -n "$BEFORE_IDS" ] && echo "📝 以前の Notion ID: $BEFORE_IDS"
```

### 変更後
```bash
if [ -n "$BEFORE_IDS" ]; then
  echo "📝 以前の Notion ID: $BEFORE_IDS"
fi
```

## 📊 影響

- ✅ BEFORE_IDS が空でもエラーにならない
- ✅ opened イベント（新規PR作成時）で正常に動作する
- ✅ 既存の機能に影響なし

## 🧪 テスト結果

### テストケース: 新規PR作成
- **イベント**: opened
- **BEFORE_TITLE**: 空文字列
- **期待**: エラーなく完了
- **結果**: ✅ 成功

---
🤖 Generated with Claude Code